### PR TITLE
fix error "Cannot choose from an empty sequence"

### DIFF
--- a/chatgpt/ChatService.py
+++ b/chatgpt/ChatService.py
@@ -25,9 +25,9 @@ class ChatService:
         self.chat_token = "gAAAAAB"
 
     async def set_dynamic_data(self, data):
-        self.proxy_url = random.choice(proxy_url_list) if proxy_url_list else None
-        self.host_url = random.choice(chatgpt_base_url_list)
-        self.arkose_token_url = random.choice(arkose_token_url_list) if arkose_token_url_list else None
+        self.proxy_url = random.choice(proxy_url_list) if len(proxy_url_list) > 0 else None
+        self.host_url = random.choice(chatgpt_base_url_list) if len(chatgpt_base_url_list) > 0 else None
+        self.arkose_token_url = random.choice(arkose_token_url_list) if len(arkose_token_url_list) > 0 else None
 
         self.s = Client(proxy=self.proxy_url)
         self.ws = None

--- a/chatgpt/chatFormat.py
+++ b/chatgpt/chatFormat.py
@@ -19,7 +19,7 @@ moderation_message = "I'm sorry, I cannot provide or engage in any content relat
 async def format_not_stream_response(response, prompt_tokens, max_tokens, model):
     chat_id = f"chatcmpl-{''.join(random.choice(string.ascii_letters + string.digits) for _ in range(29))}"
     system_fingerprint_list = model_system_fingerprint.get(model, None)
-    system_fingerprint = random.choice(system_fingerprint_list) if system_fingerprint_list else None
+    system_fingerprint = random.choice(system_fingerprint_list) if len(system_fingerprint_list) > 0 else None
     created_time = int(time.time())
     all_text = ""
     async for chunk in response:
@@ -94,7 +94,7 @@ async def wss_stream_response(websocket):
 async def stream_response(service, response, model, max_tokens):
     chat_id = f"chatcmpl-{''.join(random.choice(string.ascii_letters + string.digits) for _ in range(29))}"
     system_fingerprint_list = model_system_fingerprint.get(model, None)
-    system_fingerprint = random.choice(system_fingerprint_list) if system_fingerprint_list else None
+    system_fingerprint = random.choice(system_fingerprint_list) if len(system_fingerprint_list) > 0 else None
     created_time = int(time.time())
     completion_tokens = -1
     len_last_content = 0

--- a/chatgpt/proofofWork.py
+++ b/chatgpt/proofofWork.py
@@ -321,7 +321,7 @@ def get_config(user_agent):
         4294705152,
         0,
         user_agent,
-        random.choice(cached_scripts),
+        random.choice(cached_scripts) if len(cached_scripts) > 0 else None,
         cached_dpl,
         "en-US",
         "en-US,en",

--- a/chatgpt/refreshToken.py
+++ b/chatgpt/refreshToken.py
@@ -30,7 +30,7 @@ async def chat_refresh(refresh_token):
         "redirect_uri": "com.openai.chat://auth0.openai.com/ios/com.openai.chat/callback",
         "refresh_token": refresh_token
     }
-    client = Client(proxy=random.choice(proxy_url_list) if proxy_url_list else None)
+    client = Client(proxy=random.choice(proxy_url_list) if len(proxy_url_list) > 0 else None)
     try:
         r = await client.post("https://auth0.openai.com/oauth/token", json=data, timeout=5)
         if r.status_code == 200:

--- a/chatgpt/reverseProxy.py
+++ b/chatgpt/reverseProxy.py
@@ -100,7 +100,7 @@ async def chatgpt_reverse_proxy(request: Request, path: str):
         else:
             data = await request.body()
 
-        client = Client(proxy=random.choice(proxy_url_list) if proxy_url_list else None)
+        client = Client(proxy=random.choice(proxy_url_list) if len(proxy_url_list) > 0 else None)
         try:
             background = BackgroundTask(client.close)
             r = await client.request(request.method, f"{base_url}/{path}", params=params, headers=headers,


### PR DESCRIPTION
Python 3.11.5
request:
```
curl --location 'http://127.0.0.1:5005/v1/chat/completions' \
--header 'Content-Type: application/json' \
--data '{
     "model": "gpt-3.5-turbo",
     "messages": [{"role": "user", "content": "Say this is a test!"}],
     "stream": true
   }'
```
response:
```
{"detail":"Cannot choose from an empty sequence"}
```

报错来自于random.py,取自环境变量的proxy_url_list等变量并不是空，而是空数组，导致`random.choice([])`报错
![Screenshot 2024-05-17 at 14 59 15](https://github.com/lanqian528/chat2api/assets/29670394/96574e13-4d38-4f85-a651-68a989fc92dd)

