### PR TITLE
⭐feat 新增环境便用用于使用始皇的refresh_token转accees_token的服务

### DIFF
--- a/chatgpt/refreshToken.py
+++ b/chatgpt/refreshToken.py
@@ -43,9 +43,9 @@ async def rt2ac(refresh_token):
 async def chat_refresh(refresh_token):
     try:
         if refresh_server == "oai":
-            access_token = oai_refresh(refresh_token)
-        elif refresh_server == "oaifree":
-            access_token = oai_refresh(refresh_token)
+            access_token = await oai_refresh(refresh_token)
+        else:
+            access_token = await oaifree_refresh(refresh_token)
         return access_token
     except Exception as e:
         raise HTTPException(status_code=401, detail=str(e))
@@ -60,7 +60,7 @@ async def oai_refresh(refresh_token):
     }
     client = Client(proxy=random.choice(proxy_url_list) if proxy_url_list else None)
     try:
-        r = client.post("https://auth0.openai.com/oauth/token", json=data, timeout=5)
+        r = await client.post("https://auth0.openai.com/oauth/token", json=data, timeout=5)
         if r.status_code == 200:
             access_token = r.json()['access_token']
             return access_token
@@ -69,17 +69,17 @@ async def oai_refresh(refresh_token):
     except Exception as e:
         raise HTTPException(status_code=401, detail=str(e))
     finally:
-        client.close()
+        await client.close()
         del client
 
 
-def oaifree_refresh(refresh_token):
+async def oaifree_refresh(refresh_token):
     data = {
         'refresh_token': refresh_token,
     }
     client = Client(proxy=random.choice(proxy_url_list) if proxy_url_list else None)
     try:
-        r = client.post("https://token.oaifree.com/api/auth/refresh", json=data, timeout=5)
+        r = await client.post("https://token.oaifree.com/api/auth/refresh", data=data, timeout=5)
         if r.status_code == 200:
             access_token = r.json()['access_token']
             return access_token
@@ -88,5 +88,5 @@ def oaifree_refresh(refresh_token):
     except Exception as e:
         raise HTTPException(status_code=401, detail=str(e))
     finally:
-        client.close()
+        await client.close()
         del client

--- a/utils/config.py
+++ b/utils/config.py
@@ -30,6 +30,7 @@ enable_gateway = is_true(os.getenv('ENABLE_GATEWAY', True))
 conversation_only = is_true(os.getenv('CONVERSATION_ONLY', False))
 enable_limit = is_true(os.getenv('ENABLE_LIMIT', True))
 limit_status_code = os.getenv('LIMIT_STATUS_CODE', 429)
+refresh_server = os.getenv('RFRESH_SERVER', 'oai')
 
 authorization_list = authorization.split(',') if authorization else []
 chatgpt_base_url_list = chatgpt_base_url.split(',') if chatgpt_base_url else []
@@ -51,4 +52,6 @@ logger.info("RETRY_TIMES:       " + str(retry_times))
 logger.info("ENABLE_GATEWAY:    " + str(enable_gateway))
 logger.info("CONVERSATION_ONLY: " + str(conversation_only))
 logger.info("ENABLE_LIMIT:      " + str(enable_limit))
+logger.info("LIMIT_STATUS_CODE  " + str(limit_status_code))
+logger.info("RFRESH_SERVER:     " + str(refresh_server))
 logger.info("-" * 60)


### PR DESCRIPTION
## 本次PR的目的

* 由于可能怕过多的请求refresh_token获取access_token之后，可能会出现封ip或者封号的情况，所以新增始皇的接入点用于把`refresh_token`转为`access_token`


### 本次PR的内容
* 新增环境变量`RFRESH_SERVER`，当`RFRESH_SERVER`='oai'时，则使用官方路径用refresh)token获取access_token，否则当`RFRESH_SERVER`='oaifree'时，则使用始皇路径用refresh)token获取access_token！
* 已自测通过
![image](https://github.com/lanqian528/chat2api/assets/132346501/928ee940-0423-467c-be34-c03a28c17a7c)
