### PR TITLE
⭐优化消息里的URL访问出错导致消息无法进行的BUG

### DIFF
--- a/api/files.py
+++ b/api/files.py
@@ -15,7 +15,8 @@ async def get_file_content(url):
         client = Client()
         try:
             r = await client.get(url)
-            r.raise_for_status()
+            if r.status_code != 200:
+                return None, None
             file_content = r.content
             mime_type = r.headers.get('Content-Type', '').split(';')[0].strip()
             return file_content, mime_type

--- a/chatgpt/ChatService.py
+++ b/chatgpt/ChatService.py
@@ -410,6 +410,9 @@ class ChatService:
             return False
 
     async def upload_file(self, file_content, mime_type):
+        if not file_content or not mime_type:
+            return None
+
         width, height = None, None
         if mime_type.startswith("image/"):
             try:


### PR DESCRIPTION
### ⭐优化消息里的URL访问出错导致消息无法进行的BUG

#### 由于无法get到URL，而报错弹出
<img width="655" alt="f890569467e39ab1b4ec0db74f36f24" src="https://github.com/lanqian528/chat2api/assets/132346501/65ed35a0-fd24-4a6e-9d04-ca948ad635a4">

#### 之后收到异常，之后直接返回客户端
![71986dd7088486af303b3b7d8969e2d](https://github.com/lanqian528/chat2api/assets/132346501/b9a0b100-1eea-4724-87fe-0cbaa50d2412)


#### 优化后，就算访问不了，直接无视这条链接，使得对话能正常进行
![image](https://github.com/lanqian528/chat2api/assets/132346501/ed3178cd-abcf-4190-992f-24ef8e99b59f)

