### PR TITLE
fixbug: Avoid mapping "gpt-4-gizmo-g-id" to "gpt-4".

### DIFF
--- a/chatgpt/ChatService.py
+++ b/chatgpt/ChatService.py
@@ -136,7 +136,9 @@ class ChatService:
         else:
             self.gizmo_id = None
 
-        if "o1-preview" in self.origin_model:
+        if self.gizmo_id:
+            self.req_model = "gpt-4o"
+        elif "o1-preview" in self.origin_model:
             self.req_model = "o1-preview"
         elif "o1-pro" in self.origin_model:
             self.req_model = "o1-pro"


### PR DESCRIPTION
修复问题：当前如果通过 "gpt-4-gizmo-g-id" 的模型名称来调用 gpts，会导致模型名称被映射成 gpt-4，从而普号无法调用，而实际普号是可以通过 “g-id” 的名称进行调用的：

![image](https://github.com/user-attachments/assets/2ed85b44-8a51-4124-8232-df2c8fee28f1)

![image](https://github.com/user-attachments/assets/24567055-ddd8-4240-83e8-a6325ae6ade3)
